### PR TITLE
Add fancy flag to gold ring.

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -967,7 +967,7 @@
     "color": "yellow",
     "sided": true,
     "armor": [ { "coverage": 0, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ] } ],
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "flags": [ "FANCY", "NO_WEAR_EFFECT" ]
   },
   {
     "id": "gold_watch",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change
Fixes #57460
The gold ring was not fancy. In my experience, a real gold ring generally seems fancy, especially when it is a "flashy gold ring".
So, the gold ring needs to have the "fancy" flag added.
#### Describe the solution

Add the fancy flag to the gold ring json.

#### Describe alternatives you've considered

Give the gold ring the SUPER_FANCY flag.
Change the gold ring's description to something like "A plain, boring gold ring" to justify it not having the fancy flag.

#### Testing

Copied the change into my local up-to-date game, change worked without any bugs.


#### Additional context

This is my first PR or code contribution ever so please excuse any mistakes I made.